### PR TITLE
downgrade version of H2 used by simple monitor to make it start

### DIFF
--- a/operate-simple-monitor/docker-compose.yml
+++ b/operate-simple-monitor/docker-compose.yml
@@ -10,7 +10,7 @@ networks:
 
 services:
   db:
-    image: oscarfonts/h2
+    image: oscarfonts/h2:1.4.197
     container_name: zeebe_db
     ports:
       - "1521:1521"

--- a/simple-monitor/docker-compose.yml
+++ b/simple-monitor/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   db:
-    image: oscarfonts/h2
+    image: oscarfonts/h2:1.4.197
     container_name: zeebe_db
     ports:
       - "1521:1521"


### PR DESCRIPTION
With the latest version of oscarfonts/h2 (1.4.199) docker dependency used by simple monitor, Simple-monitor is not able to start.
This PR set the version of the dependency to 1.4.197 to make it work again.