### PR TITLE
fix(docker-compose): upgrade Zeebe simple monitor + Hazelcast exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The `docker-compose.yml` files in this repository can be used to start a single 
 
 * Zeebe 0.21.1
 * Operate 1.1.0
-* Simple Monitor 0.15.0
+* Simple Monitor 0.16.0
 
 # Profiles
 

--- a/operate-simple-monitor/docker-compose.yml
+++ b/operate-simple-monitor/docker-compose.yml
@@ -9,41 +9,29 @@ networks:
     driver: bridge
 
 services:
-  db:
-    image: oscarfonts/h2:1.4.197
-    container_name: zeebe_db
-    ports:
-      - "1521:1521"
-      - "81:81"
-    networks:
-      - zeebe_network
   zeebe:
     container_name: zeebe_broker
     image: camunda/zeebe:0.21.1
     environment:
       - ZEEBE_LOG_LEVEL=debug
-      - SIMPLE_MONITOR_EXPORTER_JDBC_URL=jdbc:h2:tcp://db:1521/zeebe-monitor
     ports:
       - "26500:26500"
       - "9600:9600"
+      - "5701:5701"
     volumes:
-      - ../lib/zeebe-hazelcast-exporter-0.5.0.jar:/usr/local/zeebe/lib/zeebe-hazelcast-exporter.jar
+      - ../lib/zeebe-hazelcast-exporter-0.6.0-jar-with-dependencies.jar:/usr/local/zeebe/lib/zeebe-hazelcast-exporter.jar
       - ./zeebe.cfg.toml:/usr/local/zeebe/conf/zeebe.cfg.toml
     networks:
       - zeebe_network
-    depends_on:
-      - db
   monitor:
     container_name: zeebe_monitor
-    image: camunda/zeebe-simple-monitor:0.15.0
+    image: camunda/zeebe-simple-monitor:0.16.0
     environment:
-      - spring.datasource.url=jdbc:h2:tcp://db:1521/zeebe-monitor
       - io.zeebe.monitor.connectionString=zeebe:26500
       - io.zeebe.monitor.hazelcast.connection=zeebe:5701
     ports:
       - "8082:8080"
     depends_on:
-      - db
       - zeebe
     restart: always
     networks:

--- a/simple-monitor/docker-compose.yml
+++ b/simple-monitor/docker-compose.yml
@@ -4,43 +4,30 @@ networks:
   zeebe_network:
     driver: bridge
 
-services:
-  db:
-    image: oscarfonts/h2:1.4.197
-    container_name: zeebe_db
-    ports:
-      - "1521:1521"
-      - "81:81"
-    networks:
-      - zeebe_network
+services:  
   zeebe:
     container_name: zeebe_broker
     image: camunda/zeebe:0.21.1
     environment:
       - ZEEBE_LOG_LEVEL=debug
-      - SIMPLE_MONITOR_EXPORTER_JDBC_URL=jdbc:h2:tcp://db:1521/zeebe-monitor
     ports:
       - "26500:26500"
       - "9600:9600"
       - "5701:5701"
     volumes:
-      - ../lib/zeebe-hazelcast-exporter-0.5.0.jar:/usr/local/zeebe/lib/zeebe-hazelcast-exporter.jar
+      - ../lib/zeebe-hazelcast-exporter-0.6.0-jar-with-dependencies.jar:/usr/local/zeebe/lib/zeebe-hazelcast-exporter.jar
       - ./zeebe.cfg.toml:/usr/local/zeebe/conf/zeebe.cfg.toml
     networks:
       - zeebe_network
-    depends_on:
-      - db
   monitor:
     container_name: zeebe_monitor
-    image: camunda/zeebe-simple-monitor:0.15.0
+    image: camunda/zeebe-simple-monitor:0.16.0
     environment:
-      - spring.datasource.url=jdbc:h2:tcp://db:1521/zeebe-monitor;DB_CLOSE_DELAY=-1
       - io.zeebe.monitor.connectionString=zeebe:26500
       - io.zeebe.monitor.hazelcast.connection=zeebe:5701
     ports:
       - "8082:8080"
     depends_on:
-      - db
       - zeebe
     restart: always
     networks:


### PR DESCRIPTION
Fix version compatibility issue with Zeebe 0.21.1 and simple monitor.

Changes:
* update Zeebe simple monitor to 0.16.0
* update Hazelcast exporter to 0.6.0