### PR TITLE
Make version 1.0 working

### DIFF
--- a/cluster/zeebe.cfg.toml
+++ b/cluster/zeebe.cfg.toml
@@ -248,7 +248,7 @@
 #   two exporters that point to the same JAR, with the same class or a different one, and use args
 #   to parametrize its instantiation.
 # className:
-#   entry point of the exporter, a class which *must* extend the io.zeebe.exporter.Exporter
+#   entry point of the exporter, a class which *must* extend the io.camunda.zeebe.exporter.Exporter
 #   interface.
 #
 # A nested table as [exporters.args] will allow you to inject arbitrary arguments into your
@@ -279,7 +279,7 @@
 #
 #[[exporters]]
 #id = "elasticsearch"
-#className = "io.zeebe.exporter.ElasticsearchExporter"
+#className = "io.camunda.zeebe.exporter.ElasticsearchExporter"
 #
 #  [exporters.args]
 #  url = "http://localhost:9200"

--- a/operate-simple-monitor/application.yaml
+++ b/operate-simple-monitor/application.yaml
@@ -88,7 +88,7 @@ zeebe:
     #
     exporters:
       elasticsearch:
-        className: io.zeebe.exporter.ElasticsearchExporter
+        className: io.camunda.zeebe.exporter.ElasticsearchExporter
 
         args:
           url: http://elasticsearch:9200

--- a/operate-simple-monitor/docker-compose.yml
+++ b/operate-simple-monitor/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - zeebe_network
   elasticsearch:
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.7.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
     ports:
       - "9200:9200"
     environment:

--- a/operate/application.yaml
+++ b/operate/application.yaml
@@ -88,7 +88,7 @@ zeebe:
     #
     exporters:
       elasticsearch:
-        className: io.zeebe.exporter.ElasticsearchExporter
+        className: io.camunda.zeebe.exporter.ElasticsearchExporter
 
         args:
           url: http://elasticsearch:9200

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     networks:
       - zeebe_network
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.7.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
     ports:
       - "9200:9200"
     environment:


### PR DESCRIPTION
- Change the io.zeebe.exporter to io.camunda.zeebe.exporter
- Update to elasticsearch-oss:7.10.2

See https://github.com/camunda-cloud/zeebe/issues/7036 and https://docs.camunda.io/docs/guides/update-guide/026-to-100/

Fixes #36